### PR TITLE
Fix: Correct specification of minSdkVersion

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,10 +36,11 @@
         <source-file src="src/android/MixpanelPlugin.java" target-dir="src/android"/>
         <source-file src="src/libs/mixpanel-android-4.5.3.jar" target-dir="libs/"/>
 
+        <preference name="android-minSdkVersion" value="9" />
+
         <!-- manifest -->
         <!-- see https://github.com/mixpanel/mixpanel-android/blob/master/src/main/AndroidManifest.xml -->
         <config-file target="AndroidManifest.xml" parent="/manifest">
-            <uses-sdk android:minSdkVersion="9"/>
             <uses-permission android:name="android.permission.INTERNET"/>
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
         </config-file>


### PR DESCRIPTION
Cordova 5.0.0 fails on a release built because the `AndroidManifest.xml` contains multiple minSdk requirements.

This PR fixes this: With this PR, the min-requirement will no longer just be copied to AndroidManifest, but instead be resolved and combined in one reasonable minSdkVersion setting. 

Please note: This was fixed after cordova 3.0.0, so probably this needs an update to https://github.com/samzilverberg/cordova-mixpanel-plugin/blob/master/plugin.xml#L18 as well.

references https://issues.apache.org/jira/browse/CB-7114
