### PR TITLE
Super properties + push notifications + distinct id + track bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ cordova plugin add https://github.com/samzilverberg/cordova-mixpanel-plugin.git
 - flush(onSuccess, onFail)
 - identify(distinctId, onSuccess, onFail)
 - init(token, onSuccess, onFail)
+- register(superProperties, onSuccess, onFail)
 - reset(onSuccess, onFail)
 - track(eventName, eventProperties, onSuccess, onFail)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ cordova plugin add https://github.com/samzilverberg/cordova-mixpanel-plugin.git
 
 - identify(distinctId, onSuccess, onFail)
 - set(peopleProperties, onSuccess, onFail)
+- registerPushToken(apnsOrGcmToken, onSuccess, onFail)
 
 
 ## TODOs

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ cordova plugin add https://github.com/samzilverberg/cordova-mixpanel-plugin.git
 
 - alias(aliasId, originalId, onSuccess, onFail)
   - also available as ```createAlias```
+- distinctId(function onSuccess(distinctId) {}, onFail)
 - flush(onSuccess, onFail)
 - identify(distinctId, onSuccess, onFail)
 - init(token, onSuccess, onFail)

--- a/src/android/MixpanelPlugin.java
+++ b/src/android/MixpanelPlugin.java
@@ -29,6 +29,7 @@ public class MixpanelPlugin extends CordovaPlugin {
         FLUSH("flush"),
         IDENTIFY("identify"),
         INIT("init"),
+        REGISTER("register"),
         RESET("reset"),
         TRACK("track"),
 
@@ -85,6 +86,8 @@ public class MixpanelPlugin extends CordovaPlugin {
                 return handleIdentify(args, cbCtx);
             case INIT:
                 return handleInit(args, cbCtx);
+            case REGISTER:
+                return handleRegister(args, cbCtx);
             case RESET:
                 return handleReset(args, cbCtx);
             case TRACK:
@@ -165,6 +168,18 @@ public class MixpanelPlugin extends CordovaPlugin {
         }
         Context ctx = cordova.getActivity();
         mixpanel = MixpanelAPI.getInstance(ctx, token);
+        cbCtx.success();
+        return true;
+    }
+
+
+    private boolean handleRegister(JSONArray args, final CallbackContext cbCtx) {
+        JSONObject superProperties = args.optJSONObject(0);
+
+        if (superProperties == null) {
+            superProperties = new JSONObject();
+        }
+        mixpanel.registerSuperProperties(superProperties);
         cbCtx.success();
         return true;
     }

--- a/src/android/MixpanelPlugin.java
+++ b/src/android/MixpanelPlugin.java
@@ -26,6 +26,7 @@ public class MixpanelPlugin extends CordovaPlugin {
 
 
         ALIAS("alias"),
+        DISTINCT_ID("distinctId"),
         FLUSH("flush"),
         IDENTIFY("identify"),
         INIT("init"),
@@ -81,6 +82,8 @@ public class MixpanelPlugin extends CordovaPlugin {
         switch (act) {
             case ALIAS:
                 return handleAlias(args, cbCtx);
+            case DISTINCT_ID:
+                return handleDistinctId(args, cbCtx);
             case FLUSH:
                 return handleFlush(args, cbCtx);
             case IDENTIFY:
@@ -133,6 +136,13 @@ public class MixpanelPlugin extends CordovaPlugin {
         }
         mixpanel.alias(aliasId, originalId);
         cbCtx.success();
+        return true;
+    }
+
+
+    private boolean handleDistinctId(JSONArray args, final CallbackContext cbCtx) {
+        String distinctId = mixpanel.getDistinctId();
+        cbCtx.success(distinctId);
         return true;
     }
 

--- a/src/android/MixpanelPlugin.java
+++ b/src/android/MixpanelPlugin.java
@@ -37,8 +37,9 @@ public class MixpanelPlugin extends CordovaPlugin {
         // PEOPLE API
 
 
-        PEOPLE_SET("people_set"),
-        PEOPLE_IDENTIFY("people_identify");
+        PEOPLE_IDENTIFY("people_identify"),
+        PEOPLE_REGISTER_PUSH_TOKEN("people_registerPushToken"),
+        PEOPLE_SET("people_set");
 
         private final String name;
         private static final Map<String, Action> lookup = new HashMap<String, Action>();
@@ -92,10 +93,12 @@ public class MixpanelPlugin extends CordovaPlugin {
                 return handleReset(args, cbCtx);
             case TRACK:
                 return handleTrack(args, cbCtx);
-            case PEOPLE_SET:
-                return handlePeopleSet(args, cbCtx);
             case PEOPLE_IDENTIFY:
                 return handlePeopleIdentify(args, cbCtx);
+            case PEOPLE_REGISTER_PUSH_TOKEN:
+                return handlePeopleRegisterPushToekn(args, cbCtx);
+            case PEOPLE_SET:
+                return handlePeopleSet(args, cbCtx);
             default:
                 this.error(cbCtx, "unknown action");
                 return false;
@@ -228,6 +231,17 @@ public class MixpanelPlugin extends CordovaPlugin {
             return false;
         }
         mixpanel.getPeople().set(properties);
+        cbCtx.success();
+        return true;
+    }
+
+    private boolean handlePeopleRegisterPushToekn(JSONArray args, final CallbackContext cbCtx) {
+        String token = args.optString(0);
+        if (token == null) {
+            this.error(cbCtx, "missing device token");
+            return false;
+        }
+        mixpanel.getPeople().initPushHandling(token);
         cbCtx.success();
         return true;
     }

--- a/src/ios/MixpanelPlugin.h
+++ b/src/ios/MixpanelPlugin.h
@@ -18,6 +18,7 @@
 -(void)flush:(CDVInvokedUrlCommand*)command;
 -(void)identify:(CDVInvokedUrlCommand*)command;
 -(void)init:(CDVInvokedUrlCommand*)command;
+-(void)register:(CDVInvokedUrlCommand*)command;
 -(void)reset:(CDVInvokedUrlCommand*)command;
 -(void)track:(CDVInvokedUrlCommand*)command;
 

--- a/src/ios/MixpanelPlugin.h
+++ b/src/ios/MixpanelPlugin.h
@@ -15,6 +15,7 @@
 
 //@see https://mixpanel.com/site_media/doctyl/uploads/iPhone-spec/Classes/Mixpanel/index.html
 -(void)alias:(CDVInvokedUrlCommand*)command;
+-(void)distinctId:(CDVInvokedUrlCommand*)command;
 -(void)flush:(CDVInvokedUrlCommand*)command;
 -(void)identify:(CDVInvokedUrlCommand*)command;
 -(void)init:(CDVInvokedUrlCommand*)command;
@@ -31,4 +32,3 @@
 -(void)people_registerPushToken:(CDVInvokedUrlCommand*)command;
 
 @end
-

--- a/src/ios/MixpanelPlugin.h
+++ b/src/ios/MixpanelPlugin.h
@@ -26,8 +26,9 @@
 // PEOPLE API
 
 
--(void)people_identify:(CDVInvokedUrlCommand*)command;
 -(void)people_set:(CDVInvokedUrlCommand*)command;
+-(void)people_identify:(CDVInvokedUrlCommand*)command;
+-(void)people_registerPushToken:(CDVInvokedUrlCommand*)command;
 
 @end
 

--- a/src/ios/MixpanelPlugin.m
+++ b/src/ios/MixpanelPlugin.m
@@ -92,6 +92,25 @@
 }
 
 
+-(void)register:(CDVInvokedUrlCommand*)command;
+{
+    CDVPluginResult* pluginResult = nil;
+    Mixpanel* mixpanelInstance = [Mixpanel sharedInstance];
+    NSDictionary* superProperties = [command.arguments objectAtIndex:0];
+
+    if (mixpanelInstance == nil)
+    {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Mixpanel not initialized"];
+    }
+    else
+    {
+        [mixpanelInstance registerSuperProperties:superProperties];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    }
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+
 -(void)reset:(CDVInvokedUrlCommand*)command;
 {
     CDVPluginResult* pluginResult = nil;
@@ -116,7 +135,7 @@
     Mixpanel* mixpanelInstance = [Mixpanel sharedInstance];
     NSArray* arguments = command.arguments;
     NSString* eventName = [arguments objectAtIndex:0];
-    NSDictionary* eventProperties = [command.arguments objectAtIndex:1];
+    NSDictionary* eventProperties = [arguments objectAtIndex:1];
 
     if (mixpanelInstance == nil)
     {

--- a/src/ios/MixpanelPlugin.m
+++ b/src/ios/MixpanelPlugin.m
@@ -30,6 +30,22 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+-(void)distinctId:(CDVInvokedUrlCommand*)command;
+{
+    CDVPluginResult* pluginResult = nil;
+    Mixpanel* mixpanelInstance = [Mixpanel sharedInstance];
+
+    if (mixpanelInstance == nil)
+    {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Mixpanel not initialized"];
+    }
+    else
+    {
+        NSString* distinctId = mixpanelInstance.distinctId;
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:distinctId];
+    }
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
 
 -(void)flush:(CDVInvokedUrlCommand*)command;
 {

--- a/src/ios/MixpanelPlugin.m
+++ b/src/ios/MixpanelPlugin.m
@@ -149,9 +149,8 @@
 {
     CDVPluginResult* pluginResult = nil;
     Mixpanel* mixpanelInstance = [Mixpanel sharedInstance];
-    NSArray* arguments = command.arguments;
-    NSString* eventName = [arguments objectAtIndex:0];
-    NSDictionary* eventProperties = [arguments objectAtIndex:1];
+    NSString* eventName = [command argumentAtIndex:0];
+    NSDictionary* eventProperties = [command argumentAtIndex:1 withDefault:@{}];
 
     if (mixpanelInstance == nil)
     {

--- a/src/ios/MixpanelPlugin.m
+++ b/src/ios/MixpanelPlugin.m
@@ -188,4 +188,24 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+-(void)people_registerPushToken:(CDVInvokedUrlCommand*)command;
+{
+    CDVPluginResult* pluginResult = nil;
+    Mixpanel* mixpanelInstance = [Mixpanel sharedInstance];
+    NSData* deviceToken =
+        [[command.arguments objectAtIndex:0] dataUsingEncoding:NSUTF8StringEncoding];
+
+    if (mixpanelInstance == nil)
+    {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Mixpanel not initialized"];
+    }
+    else
+    {
+        [mixpanelInstance.people addPushDeviceToken:deviceToken];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    }
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 @end

--- a/www/mixpanel.js
+++ b/www/mixpanel.js
@@ -8,10 +8,13 @@ var exec = require('cordova/exec'),
 
 // MIXPANEL API
 
-
 mixpanel.alias = mixpanel.createAlias = function(alias, originalId, onSuccess, onFail) {
   exec(onSuccess, onFail, 'Mixpanel', 'alias', [alias, originalId]);
 };
+
+mixpanel.distinctId = function(onSuccess, onFail) {
+  exec(onSuccess, onFail, 'Mixpanel', 'distinctId');
+}
 
 mixpanel.flush = function(onSuccess, onFail) {
   exec(onSuccess, onFail, 'Mixpanel', 'flush', []);

--- a/www/mixpanel.js
+++ b/www/mixpanel.js
@@ -25,6 +25,10 @@ mixpanel.init = function(token, onSuccess, onFail) {
   exec(onSuccess, onFail, 'Mixpanel', 'init', [token]);
 };
 
+mixpanel.register = function(superProperties, onSuccess, onFail) {
+  exec(onSuccess, onFail, 'Mixpanel', 'register', [superProperties]);
+};
+
 mixpanel.reset = function(onSuccess, onFail) {
   exec(onSuccess, onFail, 'Mixpanel', 'reset', []);
 };
@@ -45,6 +49,9 @@ mixpanel.people.set = function(peopleProperties, onSuccess, onFail) {
   exec(onSuccess, onFail, 'Mixpanel', 'people_set', [peopleProperties]);
 };
 
+mixpanel.people.registerPushToken = function(pushToken, onSuccess, onFail) {
+  exec(onSuccess, onFail, 'Mixpanel', 'people_registerPushToken', [pushToken]);
+};
 
 // Exports
 


### PR DESCRIPTION
This adds 3 new commands:

- `mixpanel.distinctId(function(distinctId) { })`
- `mixpanel.register(properties)`
- `mixpanel.registerPushToken(token)`

Also fixed a bug in the iOS code where when calling `mixpanel.track` with no properties the iOS plugin would call `[mixpanel track:properties:]` with a `NSNull` value rather than an empty `NSDictionary`, which would cause the track to fail.