### PR TITLE
Add the TimeEvent methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+### 2.1.1 2016-05-17
+- add TimeEvent methods.
+
 ### 2.1.0 2015-12-20
 - fix for distinctId by damienfa
 - browser platform supported (thanks [Damien Fa](https://github.com/damienfa))

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-mixpanel"
-        version="2.1.0">
+        version="2.1.1">
 
     <name>Mixpanel</name>
 

--- a/src/android/MixpanelPlugin.java
+++ b/src/android/MixpanelPlugin.java
@@ -34,7 +34,8 @@ public class MixpanelPlugin extends CordovaPlugin {
         RESET("reset"),
         SHOW_SURVEY("showSurvey"),
         TRACK("track"),
-
+        TIME_EVENT_START("timeEventStart"),
+        TIME_EVENT_STOP("timeEventStop"),
 
         // PEOPLE API
 
@@ -100,6 +101,10 @@ public class MixpanelPlugin extends CordovaPlugin {
                 return handleShowSurvey(args, cbCtx);
             case TRACK:
                 return handleTrack(args, cbCtx);
+            case TIME_EVENT_START:
+                return startTimeEvent(args, cbCtx);
+            case TIME_EVENT_STOP:
+                return stopTimeEvent(args, cbCtx);
             case PEOPLE_IDENTIFY:
                 return handlePeopleIdentify(args, cbCtx);
             case PEOPLE_INCREMENT:
@@ -213,6 +218,20 @@ public class MixpanelPlugin extends CordovaPlugin {
             properties = new JSONObject();
         }
         mixpanel.track(event, properties);
+        cbCtx.success();
+        return true;
+    }
+
+    private boolean startTimeEvent(JSONArray args, final CallbackContext cbCtx) {
+        String event = args.optString(0, "");
+        mixpanel.timeEvent(event);
+        cbCtx.success();
+        return true;
+    }
+    
+    private boolean stopTimeEvent(JSONArray args, final CallbackContext cbCtx) {
+        String event = args.optString(0, "");
+        mixpanel.track(event);
         cbCtx.success();
         return true;
     }

--- a/src/ios/MixpanelPlugin.m
+++ b/src/ios/MixpanelPlugin.m
@@ -171,6 +171,24 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+-(void)timeEventStart:(CDVInvokedUrlCommand*)command;
+{
+    CDVPluginResult* pluginResult = nil;
+    Mixpanel* mixpanelInstance = [Mixpanel sharedInstance];
+    NSString* eventName = [command argumentAtIndex:0];
+
+    [mixpanel timeEvent:eventName];
+}
+
+-(void)timeEventStop:(CDVInvokedUrlCommand*)command;
+{
+    CDVPluginResult* pluginResult = nil;
+    Mixpanel* mixpanelInstance = [Mixpanel sharedInstance];
+    NSString* eventName = [command argumentAtIndex:0];
+
+    [mixpanel track:eventName];
+}
+
 
 // PEOPLE API
 

--- a/src/ios/MixpanelPlugin.m
+++ b/src/ios/MixpanelPlugin.m
@@ -177,7 +177,16 @@
     Mixpanel* mixpanelInstance = [Mixpanel sharedInstance];
     NSString* eventName = [command argumentAtIndex:0];
 
-    [mixpanel timeEvent:eventName];
+    if (mixpanelInstance == nil)
+    {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Mixpanel not initialized"];
+    }
+    else
+    {
+        [mixpanelInstance timeEvent:eventName];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    }
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 -(void)timeEventStop:(CDVInvokedUrlCommand*)command;
@@ -186,7 +195,17 @@
     Mixpanel* mixpanelInstance = [Mixpanel sharedInstance];
     NSString* eventName = [command argumentAtIndex:0];
 
-    [mixpanel track:eventName];
+
+    if (mixpanelInstance == nil)
+    {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Mixpanel not initialized"];
+    }
+    else
+    {
+        [mixpanelInstance track:eventName properties:nil];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    }
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 

--- a/typings/mixpanel.d.ts
+++ b/typings/mixpanel.d.ts
@@ -1,0 +1,40 @@
+
+interface IMixpanel {
+
+    people:Mixpanel.IPeople;
+
+    init(token:string, onSuccess:() => void, onFail:(errors:string) => void):void;
+
+    alias(alias:string, originalId:string, onSuccess:() => void, onFail:(errors:string) => void):void;
+    createAlias(alias:string, originalId:string, onSuccess:() => void, onFail:(errors:string) => void):void;
+
+    distinctId(onSuccess:() => void, onFail:(errors:string) => void):void;
+
+    flush(onSuccess:() => void, onFail:(errors:string) => void):void;
+    identify(id:string, onSuccess:() => void, onFail:(errors:string) => void):void;
+
+    registerSuperProperties(superProperties:any, onSuccess:() => void, onFail:(errors:string) => void):void;
+    reset(onSuccess:() => void, onFail:(errors:string) => void):void;
+    showSurvey(onSuccess:() => void, onFail:(errors:string) => void):void;
+
+    track(eventName:string, eventProperties:any, onSuccess:() => void, onFail:(errors:string) => void):void;
+
+    timeEventStart(eventName:string, onSuccess:() => void, onFail:(errors:string) => void):void;
+    timeEventStop(eventName:string, onSuccess:() => void, onFail:(errors:string) => void):void;
+}
+
+
+declare namespace Mixpanel
+{
+    interface IPeople{
+        identify(distinctId:string, onSuccess:() => void, onFail:(errors:string) => void):void;
+        set(peopleProperties:any, onSuccess:() => void, onFail:(errors:string) => void):void;
+        setOnce(peopleProperties:any, onSuccess:() => void, onFail:(errors:string) => void):void;
+
+        increment(peopleProperties:any, onSuccess:() => void, onFail:(errors:string) => void):void;
+        setPushId(pushId:string, onSuccess:() => void, onFail:(errors:string) => void):void;
+    }
+}
+
+declare var mixpanel:IMixpanel;
+

--- a/www/mixpanel.js
+++ b/www/mixpanel.js
@@ -70,6 +70,20 @@ mixpanel.track = function(eventName, eventProperties, onSuccess, onFail) {
   exec(onSuccess, onFail, 'Mixpanel', 'track', [eventName, eventProperties]);
 };
 
+mixpanel.timeEventStart = function(eventName, onSuccess, onFail){
+  if (!eventName || typeof eventName != 'string') {
+    return onFail(errors.invalid('event', eventName));
+  }
+  exec(onSuccess, onFail, 'Mixpanel', 'timeEventStart', [eventName, eventProperties]);
+};
+
+mixpanel.timeEventStop = function(eventName, onSuccess, onFail){
+  if (!eventName || typeof eventName != 'string') {
+    return onFail(errors.invalid('event', eventName));
+  }
+  exec(onSuccess, onFail, 'Mixpanel', 'timeEventStop', [eventName, eventProperties]);
+};
+
 
 // PEOPLE API
 

--- a/www/mixpanel.js
+++ b/www/mixpanel.js
@@ -74,14 +74,14 @@ mixpanel.timeEventStart = function(eventName, onSuccess, onFail){
   if (!eventName || typeof eventName != 'string') {
     return onFail(errors.invalid('event', eventName));
   }
-  exec(onSuccess, onFail, 'Mixpanel', 'timeEventStart', [eventName, eventProperties]);
+  exec(onSuccess, onFail, 'Mixpanel', 'timeEventStart', [eventName]);
 };
 
 mixpanel.timeEventStop = function(eventName, onSuccess, onFail){
   if (!eventName || typeof eventName != 'string') {
     return onFail(errors.invalid('event', eventName));
   }
-  exec(onSuccess, onFail, 'Mixpanel', 'timeEventStop', [eventName, eventProperties]);
+  exec(onSuccess, onFail, 'Mixpanel', 'timeEventStop', [eventName]);
 };
 
 


### PR DESCRIPTION
I have added a start and stop TimeEvent methods.  Mixpanel supports TimeEvent to be fired prior to a track event to add duration to the actual event.  This can be quite useful for tracking how long things take or user dwell times in sections of your App.  I added the stop method as a simple method rather than using Track, but you can use track as long as the eventName is the same.

Hope that makes sense.