### PR TITLE
Make this plugin compatible with others

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,7 +33,8 @@
         <!-- Plugin files -->
         <source-file src="src/android/MixpanelPlugin.java" target-dir="src/android"/>
         <framework src="com.mixpanel.android:mixpanel-android:4.9.1"/>
-        <framework src="com.google.android.gms:play-services:3.1+"/>
+        <framework src="com.google.android.gms:play-services-base:+"/>
+        <framework src="com.google.android.gms:play-services-gcm:+"/>
 
         <!-- AndroidManifest.xml -->
         <!-- see https://github.com/mixpanel/mixpanel-android/blob/master/src/main/AndroidManifest.xml -->


### PR DESCRIPTION
Doing this people will be able to install more plugins using other versions of Google Play Services.

I know the versions for this plugin should be the ones stated in their documentation, you can check them here: https://github.com/mixpanel/mixpanel-android/blob/5cdbc12b172f61b7be7c2d14584015accb83f12a/build.gradle#L38-L39

But unless we do this, we couldn't install multiple plugins with different GPS versions.