### PR TITLE
Add `mixpanel.people.track_charge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ older versions:
   ```
 - set(peopleProperties, onSuccess, onFail)
 - setOnce(peopleProperties, onSuccess, onFail)
+- trackCharge(charge, eventProperties, onSuccess, onFail)
 
 
 ## TODOs

--- a/src/android/MixpanelPlugin.java
+++ b/src/android/MixpanelPlugin.java
@@ -44,6 +44,7 @@ public class MixpanelPlugin extends CordovaPlugin {
         PEOPLE_SET_PUSH_ID("people_setPushId"),
         PEOPLE_SET("people_set"),
         PEOPLE_SET_ONCE("people_set_once");
+        PEOPLE_TRACK_CHARGE("people_track_charge");
 
         private final String name;
         private static final Map<String, Action> lookup = new HashMap<String, Action>();
@@ -112,6 +113,8 @@ public class MixpanelPlugin extends CordovaPlugin {
                 return handlePeopleSet(args, cbCtx);
             case PEOPLE_SET_ONCE:
                 return handlePeopleSetOnce(args, cbCtx);
+            case PEOPLE_TRACK_CHARGE:
+                return handlePeopleTrackCharge(args, cbCtx);
             default:
                 this.error(cbCtx, "unknown action");
                 return false;
@@ -279,6 +282,17 @@ public class MixpanelPlugin extends CordovaPlugin {
     private boolean handlePeopleSetPushId(JSONArray args, final CallbackContext cbCtx) {
         String pushId = args.optString(0);
         mixpanel.getPeople().setPushRegistrationId(pushId);
+        cbCtx.success();
+        return true;
+    }
+
+    private boolean handlePeopleTrackCharge(JSONArray args, final CallbackContext cbCtx) {
+        Double charge = args.optString(0, 0.0);
+        JSONObject properties = args.optJSONObject(1);
+        if (properties == null) {
+            properties = new JSONObject();
+        }
+        mixpanel.getPeople().trackCharge(charge, properties);
         cbCtx.success();
         return true;
     }

--- a/src/android/MixpanelPlugin.java
+++ b/src/android/MixpanelPlugin.java
@@ -286,8 +286,9 @@ public class MixpanelPlugin extends CordovaPlugin {
         return true;
     }
 
+
     private boolean handlePeopleTrackCharge(JSONArray args, final CallbackContext cbCtx) {
-        Double charge = args.optString(0, 0.0);
+        Double charge = args.optDouble(0, 0.0);
         JSONObject properties = args.optJSONObject(1);
         if (properties == null) {
             properties = new JSONObject();

--- a/src/browser/MixpanelProxy.js
+++ b/src/browser/MixpanelProxy.js
@@ -168,6 +168,29 @@ function on_mixpanel_loaded() {
 
   };
 
+
+  // TRACK CHARGE
+  mixpanel.people.original_track_charge = mixpanel.people.track_charge;
+  mixpanel.people.track_charge = function(charge, eventProperties, onSuccess, onFail) {
+
+    if (!charge || typeof charge != 'number') {
+      if (onFail && typeof onFail === 'function')
+        return onFail(errors.invalid('charge', charge));
+    }
+
+    mixpanel.people.original_track_charge(charge, eventProperties, function(r) {
+      if (!r) {
+        if (onFail && typeof onFail === 'function')
+          return onFail(errors.invalid('people.track_charge', charge));
+      } else {
+        if (onSuccess && typeof onSuccess === 'function')
+          return onSuccess();
+      }
+    });
+
+  };
+
+
   mixpanel.people.original_increment = mixpanel.people.increment;
   mixpanel.people.increment = function(peopleProperties, onSuccess, onFail) {
     if (!peopleProperties || (typeof peopleProperties === 'object' && Object.keys(peopleProperties).length === 0)) {

--- a/src/ios/MixpanelPlugin.h
+++ b/src/ios/MixpanelPlugin.h
@@ -31,6 +31,7 @@
 
 -(void)people_identify:(CDVInvokedUrlCommand*)command;
 -(void)people_increment:(CDVInvokedUrlCommand*)command;
+-(void)people_track_charge:(CDVInvokedUrlCommand*)command;
 -(void)people_setPushId:(CDVInvokedUrlCommand*)command;
 -(void)people_set:(CDVInvokedUrlCommand*)command;
 -(void)people_set_once:(CDVInvokedUrlCommand*)command;

--- a/src/ios/MixpanelPlugin.m
+++ b/src/ios/MixpanelPlugin.m
@@ -245,6 +245,26 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+-(void)people_track_charge:(CDVInvokedUrlCommand*)command;
+{
+    CDVPluginResult* pluginResult = nil;
+    Mixpanel* mixpanelInstance = [Mixpanel sharedInstance];
+    double* charge = [command argumentAtIndex:0];
+    NSDictionary* eventProperties = [command argumentAtIndex:1 withDefault:@{}];
+
+    if (mixpanelInstance == nil)
+    {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Mixpanel not initialized"];
+    }
+    else
+    {
+        [mixpanelInstance.people trackCharge:charge properties:eventProperties];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    }
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+
 
 -(void)people_setPushId:(CDVInvokedUrlCommand*)command;
 {

--- a/typings/mixpanel.d.ts
+++ b/typings/mixpanel.d.ts
@@ -22,7 +22,7 @@ declare namespace Mixpanel {
     identify(distinctId: string, onSuccess: () => void, onFail: (errors: string) => void): void;
     set(peopleProperties: any, onSuccess: () => void, onFail: (errors: string) => void): void;
     setOnce(peopleProperties: any, onSuccess: () => void, onFail: (errors: string) => void): void;
-
+    trackCharge(charge: number, eventProperties: any, onSuccess: () => void, onFail: (errors: string) => void): void;
     increment(peopleProperties: any, onSuccess: () => void, onFail: (errors: string) => void): void;
     setPushId(pushId: string, onSuccess: () => void, onFail: (errors: string) => void): void;
   }

--- a/www/mixpanel.js
+++ b/www/mixpanel.js
@@ -105,6 +105,16 @@ mixpanel.people.setOnce = function(peopleProperties, onSuccess, onFail) {
   exec(onSuccess, onFail, 'Mixpanel', 'people_set_once', [peopleProperties]);
 };
 
+mixpanel.people.trackCharge = function(charge, eventProperties, onSuccess, onFail) {
+  if (!peopleProperties || (typeof peopleProperties === 'object' && Object.keys(peopleProperties).length === 0)) {
+    return onFail(errors.invalid('properties', peopleProperties));
+  }
+
+
+  exec(onSuccess, onFail, 'Mixpanel', 'people_track_charge', [charge, peopleProperties]);
+};
+
+
 mixpanel.people.increment = function(peopleProperties, onSuccess, onFail) {
   if (!peopleProperties || (typeof peopleProperties === 'object' && Object.keys(peopleProperties).length === 0)) {
     return onFail(errors.invalid('properties', peopleProperties));


### PR DESCRIPTION
As discussed in issue #35, here's an attempt at implementing the missing `people.track_charge` method.

I hope it gets most of the boilerplate done, however I must stress it doesn't work in the current version. The iOS implementation has been written more or less blindly, as I don't have an Apple dev environment.

Hope this helps!
