### PR TITLE
set __loaded flag

### DIFF
--- a/www/mixpanel.js
+++ b/www/mixpanel.js
@@ -39,6 +39,8 @@ mixpanel.identify = function(id, onSuccess, onFail) {
 };
 
 mixpanel.init = function(token, onSuccess, onFail) {
+  this['__loaded'] = true;
+
   if (!token || typeof token != 'string') {
     return onFail(errors.invalid('token', token));
   }


### PR DESCRIPTION
__loaded flag must to be set tu true in int function.  Angulartics mixpanel plugin is checking this property in  waitForVendorApi function.

` angulartics.waitForVendorApi('mixpanel', 500, '__loaded', function (mixpanel) {
...
}`

[angulartics-mixpanel](https://github.com/angulartics/angulartics-mixpanel/blob/master/lib/angulartics-mixpanel.js)



Otherwise [Angulartics ](http://angulartics.github.io/ )will not start tracking.