### PR TITLE
supply play services version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,24 @@ requires cordova >5.x.x
   cordova plugin add cordova-plugin-mixpanel
 ```
 
+*Optional*: If you want to explicitly specify a google play services version to work with other existing plugins in your project, you can specify a flag `PLAY_SERVICES_VERSION` during installation. e.g. 11.8.0. If you don't provide this flag, it will assume the default '+' wildcard version
+
+```
+cordova plugin add cordova-plugin-mixpanel --variable PLAY_SERVICES_VERSION="11.8.0"
+```
+
 #### Initialization and quick start
 
 init the plugin with your mixpanel project token with
 ```
-  mixpanel.init(your-token, 
-    function(){ /* successful init */ }, 
+  mixpanel.init(your-token,
+    function(){ /* successful init */ },
     function(){ /* fail */})
 ```
 and then followup with all your favorite mixpanel functionality.<br/>
 `mixpanel.track` to track events.<br/>
-`alias` or `identify` (depending on use case) to set the id for people events (after login or register).<br/>  
-`people.set` to set properties on the people entity identified before.<br/> 
+`alias` or `identify` (depending on use case) to set the id for people events (after login or register).<br/>
+`people.set` to set properties on the people entity identified before.<br/>
 you can read more about mixpanel api in their reference: https://mixpanel.com/help/reference <br/>
 
 
@@ -90,7 +96,7 @@ https://www.npmjs.com/package/cordova-mixpanel-plugin-testapp
 
 ## License Notice
 
-All Mixpanel ios sdk source files under `src/ios/Mixpanel` are licensed under the apache license.<br/>  
+All Mixpanel ios sdk source files under `src/ios/Mixpanel` are licensed under the apache license.<br/>
 A copy of the license is located at `src/ios/Mixpanel/LICENSE`.<br/>
 
 The rest of the code is MIT license, located at `/LICENSE`.

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,8 +29,16 @@
         <!-- Plugin files -->
         <source-file src="src/android/MixpanelPlugin.java" target-dir="src/android"/>
         <framework src="com.mixpanel.android:mixpanel-android:5.2.4"/>
-        <framework src="com.google.android.gms:play-services-base:+"/>
-        <framework src="com.google.android.gms:play-services-gcm:+"/>
+
+        <!--
+        Minimum required version of Google Play Services SDK for this plugin is + (as per current version).
+        You can optionally specify a version number to align the version with other plugins that utilize gcm.
+        https://developers.google.com/android/guides/releases
+        -->
+        <preference name="PLAY_SERVICES_VERSION" default="+" />
+
+        <framework src="com.google.android.gms:play-services-base:$PLAY_SERVICES_VERSION"/>
+        <framework src="com.google.android.gms:play-services-gcm:$PLAY_SERVICES_VERSION"/>
 
         <!-- AndroidManifest.xml -->
         <!-- see https://github.com/mixpanel/mixpanel-android/blob/master/src/main/AndroidManifest.xml -->


### PR DESCRIPTION
Tested on 

```
global packages:

    cordova (Cordova CLI) : 8.0.0
    cordova Android : 7.1.0

local packages:

    @ionic/app-scripts : 3.1.8
    Cordova Platforms  : none
    Ionic Framework    : ionic-angular 3.9.2

System:

    Android SDK Tools : 26.1.1
    Node              : v8.10.0
    npm               : 5.7.1
    OS                : Windows 10
```

**Testing**
Adding the plugin with my modifications would pin play services to its required version

`cordova plugin add https://github.com/akhatri/cordova-mixpanel-plugin.git#feat-provide-play-services-version --variable PLAY_SERVICES_VERSION="11.8.0"`