### PR TITLE
Fix build error for newer MixPanel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Init the plugin with your mixpanel project token with
 ```
   mixpanel.init(your-token,
     function(){ /* successful init */ },
-    function(){ /* fail */})
+    function(){ /* fail */},
+    trackAutomaticEvents)
 ```
 and then followup with all your favorite mixpanel functionality.<br/>
 `mixpanel.track` to track events.<br/>
@@ -55,7 +56,9 @@ You can read more about mixpanel api in their reference: https://mixpanel.com/he
 - identify(distinctId, onSuccess, onFail)
 - identify(distinctId, usePeople, onSuccess, onFail)
   - only affects ios: will pass `usePeople` to the ios mixpanel sdk identify method
-- init(token, onSuccess, onFail)
+- init(token, onSuccess, onFail, trackAutomaticEvents)
+  - `trackAutomaticEvents` only affects android, and defaults to true if not provided.   
+    `trackAutomaticEvents` indicates whether or not to collect common mobile events include app sessions, first app opens, app updated, etc.
 - registerSuperProperties(superProperties, onSuccess, onFail)
 - registerSuperPropertiesOnce(superProperties, onSuccess, onFail)
 - reset(onSuccess, onFail)

--- a/src/android/MixpanelPlugin.java
+++ b/src/android/MixpanelPlugin.java
@@ -213,7 +213,7 @@ public class MixpanelPlugin extends CordovaPlugin {
     private boolean handleInit(JSONArray args, final CallbackContext cbCtx) {
         String token = args.optString(0, "");
         Context ctx = cordova.getActivity();
-        mixpanel = MixpanelAPI.getInstance(ctx, token);
+        mixpanel = MixpanelAPI.getInstance(ctx, token, true);
         cbCtx.success();
         return true;
     }

--- a/src/android/MixpanelPlugin.java
+++ b/src/android/MixpanelPlugin.java
@@ -212,8 +212,10 @@ public class MixpanelPlugin extends CordovaPlugin {
 
     private boolean handleInit(JSONArray args, final CallbackContext cbCtx) {
         String token = args.optString(0, "");
+        boolean trackAutomaticEvents = args.optBoolean(1, true);
+        
         Context ctx = cordova.getActivity();
-        mixpanel = MixpanelAPI.getInstance(ctx, token, true);
+        mixpanel = MixpanelAPI.getInstance(ctx, token, trackAutomaticEvents);
         cbCtx.success();
         return true;
     }

--- a/src/android/MixpanelPlugin.java
+++ b/src/android/MixpanelPlugin.java
@@ -213,7 +213,6 @@ public class MixpanelPlugin extends CordovaPlugin {
     private boolean handleInit(JSONArray args, final CallbackContext cbCtx) {
         String token = args.optString(0, "");
         boolean trackAutomaticEvents = args.optBoolean(1, true);
-        
         Context ctx = cordova.getActivity();
         mixpanel = MixpanelAPI.getInstance(ctx, token, trackAutomaticEvents);
         cbCtx.success();

--- a/typings/mixpanel.d.ts
+++ b/typings/mixpanel.d.ts
@@ -2,7 +2,7 @@ interface IMixpanel {
 
   people: Mixpanel.IPeople;
 
-  init(token: string, onSuccess: () => void, onFail: (errors: string) => void): void;
+  init(token: string, onSuccess: () => void, onFail: (errors: string) => void, trackAutomaticEvents: boolean): void;
 
   alias(alias: string, originalId: string, onSuccess: () => void, onFail: (errors: string) => void): void;
   createAlias(alias: string, originalId: string, onSuccess: () => void, onFail: (errors: string) => void): void;

--- a/typings/mixpanel.d.ts
+++ b/typings/mixpanel.d.ts
@@ -2,7 +2,7 @@ interface IMixpanel {
 
   people: Mixpanel.IPeople;
 
-  init(token: string, onSuccess: () => void, onFail: (errors: string) => void, trackAutomaticEvents: boolean): void;
+  init(token: string, onSuccess: () => void, onFail: (errors: string) => void, trackAutomaticEvents?: boolean): void;
 
   alias(alias: string, originalId: string, onSuccess: () => void, onFail: (errors: string) => void): void;
   createAlias(alias: string, originalId: string, onSuccess: () => void, onFail: (errors: string) => void): void;

--- a/www/mixpanel.js
+++ b/www/mixpanel.js
@@ -77,7 +77,7 @@ mixpanel.identify = function(id, usePeople, onSuccess, onFail) {
   exec(onSuccess, onFail, 'Mixpanel', 'identify', [id, !!usePeople]);
 };
 
-mixpanel.init = function(token, onSuccess, onFail) {
+mixpanel.init = function(token, onSuccess, onFail, trackAutomaticEvents) {
   if (!token || typeof token != 'string') {
     return onFail(errors.invalid('token', token));
   }
@@ -87,7 +87,7 @@ mixpanel.init = function(token, onSuccess, onFail) {
     onSuccess.apply(onSuccess, arguments);
   }
 
-  exec(onSuccessWrapper, onFail, 'Mixpanel', 'init', [token]);
+  exec(onSuccessWrapper, onFail, 'Mixpanel', 'init', [token, trackAutomaticEvents]);
 };
 
 mixpanel.registerSuperProperties = function(superProperties, onSuccess, onFail) {


### PR DESCRIPTION
Initialize MixPanel with trackAutomaticEvents set to true to fix a build error in newer versions of the MixPanel SDK